### PR TITLE
fix missing symbol rados_set/unset_pool_full_try, M1 improvements

### DIFF
--- a/ceph-client.rb
+++ b/ceph-client.rb
@@ -32,6 +32,11 @@ class CephClient < Formula
     sha256 "b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"
   end
 
+  resource "wcwidth" do
+    url "https://files.pythonhosted.org/packages/89/38/459b727c381504f361832b9e5ace19966de1a235d73cdbdea91c771a1155/wcwidth-0.2.5.tar.gz"
+    sha256 "c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"
+  end
+
   patch :DATA
 
   def install

--- a/ceph-client.rb
+++ b/ceph-client.rb
@@ -206,3 +206,24 @@ index 8dc69f0af51..0b2acaf160a 100644
                          -D'void0=dead_function\(void\)' \
                          -D'__Pyx_check_single_interpreter\(ARG\)=ARG \#\# 0' \
 
+diff --git a/src/librados/librados_c.cc b/src/librados/librados_c.cc
+index ae4a0e9dbb5..00fe0992abd 100644
+--- a/src/librados/librados_c.cc
++++ b/src/librados/librados_c.cc
+@@ -532,14 +532,14 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_unset_osdmap_full_try)(
+ }
+ LIBRADOS_C_API_BASE_DEFAULT(rados_unset_pool_full_try);
+
+-extern "C" void _rados_set_pool_full_try(rados_ioctx_t io)
++extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_set_pool_full_try)(rados_ioctx_t io)
+ {
+   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+   ctx->extra_op_flags |= CEPH_OSD_FLAG_FULL_TRY;
+ }
+ LIBRADOS_C_API_BASE_DEFAULT(rados_set_pool_full_try);
+
+-extern "C" void _rados_unset_pool_full_try(rados_ioctx_t io)
++extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_unset_pool_full_try)(rados_ioctx_t io)
+ {
+   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+   ctx->extra_op_flags &= ~CEPH_OSD_FLAG_FULL_TRY;

--- a/ceph-client.rb
+++ b/ceph-client.rb
@@ -141,6 +141,14 @@ class CephClient < Formula
     end
 
     bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
+    %w[
+      ceph-conf
+      ceph-fuse
+      rados
+      rbd
+    ].each do |name|
+      system "install_name_tool", "-add_rpath", "/opt/homebrew/lib", "#{libexec}/bin/#{name}"
+    end
   end
 
   def caveats; <<~EOS


### PR DESCRIPTION
On the current revision the two API methods have a _ appended to them and they don't match the librados C api name, on ceph/master this is already fixed.
After fixing this, `ceph -h` had a missing python module "wcwidth".
Lastly, because on M1 homebrew installs libraries and include folders now to "/opt/homebrew/(include|lib)" by default for arm64, the executables will complain that they can't find the libraries needed on the given rpath which searches in "/usr/local/lib" and "/usr/lib". I tried using `MachO.open(file).add_rpath` and `MachO::Tools.add_rpath` with no success, looks like the syscall works.

fixes #13 #16