### PR TITLE
Downgrade boost dependency to below 1.81

### DIFF
--- a/ceph-client.rb
+++ b/ceph-client.rb
@@ -12,7 +12,7 @@ class CephClient < Formula
   end
 
   # depends_on "osxfuse"
-  depends_on "boost"
+  depends_on "boost@1.76"
   depends_on "openssl" => :build
   depends_on "cmake" => :build
   depends_on "ninja" => :build


### PR DESCRIPTION
... to avoid boost::phoenix::placeholder::uargX duplicate symbol errors

Addresses #25