### PR TITLE
Fix error with new p3.12 ver

### DIFF
--- a/ceph-client.rb
+++ b/ceph-client.rb
@@ -20,7 +20,7 @@ class CephClient < Formula
   depends_on "leveldb" => :build
   depends_on "nss"
   depends_on "pkg-config" => :build
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "sphinx-doc" => :build
   depends_on "yasm"
   def caveats
@@ -77,7 +77,7 @@ class CephClient < Formula
       -DWITH_MANPAGE=ON
       -DWITH_MGR=OFF
       -DWITH_MGR_DASHBOARD_FRONTEND=OFF
-      -DWITH_PYTHON3=3.11
+      -DWITH_PYTHON3=3.12
       -DWITH_RADOSGW=OFF
       -DWITH_RDMA=OFF
       -DWITH_SPDK=OFF
@@ -215,7 +215,7 @@ index 9d66ae979a6..eabf22bf174 100644
      set(ENV{CEPH_LIBDIR} \"${CMAKE_LIBRARY_OUTPUT_DIRECTORY}\")
 
 -    set(options --prefix=${CMAKE_INSTALL_PREFIX})
-+    set(options --prefix=${CMAKE_INSTALL_PREFIX} --install-lib=${CMAKE_INSTALL_PREFIX}/lib/python3.11/site-packages)
++    set(options --prefix=${CMAKE_INSTALL_PREFIX} --install-lib=${CMAKE_INSTALL_PREFIX}/lib/python3.12/site-packages)
      if(DEFINED ENV{DESTDIR})
        if(EXISTS /etc/debian_version)
          list(APPEND options --install-layout=deb)


### PR DESCRIPTION
The most current version of Python that users use is 3.12. it's time to update it in the code too
Current time many users run comman
`brew install ceph-client --verbose --debug`
and face with the problem:
```
==> Installing mulbc/ceph-client/ceph-client
==> Patching
Error: An exception occurred within a child process:
  Errno::EPERM: Operation not permitted @ dir_s_mkdir - /usr/local/opt/cython/libexec/lib/python3.11
```
  I think we need to use the current version for today